### PR TITLE
Fix LTR not being applied to lines

### DIFF
--- a/styles/force-text-direction.less
+++ b/styles/force-text-direction.less
@@ -27,7 +27,7 @@ atom-pane-container atom-pane {
 
 		border-left: 1px solid rgb(220, 50, 47);
 
-	 	.editor-contents .lines .line {
+	 	.line {
 			direction: ltr;
 			unicode-bidi: bidi-override;
 		}
@@ -43,7 +43,7 @@ atom-pane-container atom-pane {
 
 		border-right: 1px solid rgb(220, 50, 47);
 
-		.editor-contents .lines .line {
+		.line {
 			direction: rtl;
 			unicode-bidi: bidi-override;
 		}


### PR DESCRIPTION
Because of what I'm assuming were changes to the style structure in Atom, lines weren't being selected correctly by the CSS and so LTR wasn't being forced. I relaxed the style selectors a bit so the lines would be caught again and the plugin would work as intended.